### PR TITLE
remove contentsモデルからabout,imageカラム削除

### DIFF
--- a/app/views/contents/edit.html.erb
+++ b/app/views/contents/edit.html.erb
@@ -7,11 +7,6 @@
       <%= render 'shared/error_messages', object: @content, attribute: :title %>
     </div>
 
-    <div class = "field">
-      <%= form.label :about %>
-      <%= form.text_field :about %>
-    </div>
-
     <div class="field">
       <%= form.label :category_id %>
       <%= form.collection_select :category_id, Category.all, :id, :title, { prompt: '選択してください'} %>
@@ -20,11 +15,6 @@
 
     <div class = "category-message">
       <p>該当するカテゴリーがない場合、<%= link_to 'こちら', categories_path %>から登録してください。</p>
-    </div>
-
-    <div class="field">
-      <%= form.label :image %>
-      <%= form.text_field :image %>
     </div>
 
     <div class="field">

--- a/app/views/contents/new.html.erb
+++ b/app/views/contents/new.html.erb
@@ -7,11 +7,6 @@
       <%= render 'shared/error_messages', object: @content, attribute: :title %>
     </div>
 
-    <div class = "field">
-      <%= form.label :about %>
-      <%= form.text_field :about %>
-    </div>
-
     <div class="field">
       <%= form.label :category_id %>
       <%= form.collection_select :category_id, Category.all, :id, :title, { prompt: '選択してください'} %>
@@ -20,11 +15,6 @@
 
     <div class = "category-message">
       <p>該当するカテゴリーがない場合、<%= link_to 'こちら', categories_path %>から登録してください。</p>
-    </div>
-
-    <div class="field">
-      <%= form.label :image %>
-      <%= form.text_field :image %>
     </div>
 
     <div class="field">

--- a/db/migrate/20230501081448_remove_column_to_contents.rb
+++ b/db/migrate/20230501081448_remove_column_to_contents.rb
@@ -1,0 +1,6 @@
+class RemoveColumnToContents < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :contents, :about, :string
+    remove_column :contents, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_30_133147) do
+ActiveRecord::Schema.define(version: 2023_05_01_081448) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -69,9 +69,7 @@ ActiveRecord::Schema.define(version: 2023_04_30_133147) do
 
   create_table "contents", force: :cascade do |t|
     t.string "title"
-    t.string "about"
     t.integer "category_id"
-    t.string "image"
     t.string "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
  create_table "contents", force: :cascade do |t|
    t.string "title"
    t.integer "category_id"
    t.string "description"
    t.datetime "created_at", precision: 6, null: false
    t.datetime "updated_at", precision: 6, null: false
    t.integer "user_id", null: false
    t.string "video"
    t.string "admin_id", default: "", null: false
    t.index ["user_id"], name: "index_contents_on_user_id"
  end
  
  現状の形からabout,image削除。

> about・・・rich_textが同類の役目をするため
> image・・・同上 