### PR TITLE
動画ファイル関連をcontents/showに表示する仕様

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-debug.log*
 .yarn-integrity
 .DS_Store
 .env
+/public/uploads

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -61,7 +61,7 @@ class ContentsController < ApplicationController
   end
 
   def content_params
-    params.require(:content).permit(:title, :about, :category_id, :image, :description, :text, :video)
+    params.require(:content).permit(:title, :about, :category_id, :image, :description, :text, :video, :youtube_url)
   end
 
   def set_content

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -2,13 +2,4 @@
   <% if blob.representable? %>
     <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
   <% end %>
-
-  <figcaption class="attachment__caption">
-    <% if caption = blob.try(:caption) %>
-      <%= caption %>
-    <% else %>
-      <span class="attachment__name"><%= blob.filename %></span>
-      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
-    <% end %>
-  </figcaption>
 </figure>

--- a/app/views/contents/edit.html.erb
+++ b/app/views/contents/edit.html.erb
@@ -28,6 +28,11 @@
       <%= form.file_field :video %>
     </div>
 
+    <div class = "field">
+      <%= form.label :youtube_url%>
+      <%= form.text_field :youtube_url %>
+    </div>    
+
     <div class="field">
       <%= form.label :text %>
       <%= form.rich_text_area :text %>

--- a/app/views/contents/index.html.erb
+++ b/app/views/contents/index.html.erb
@@ -9,8 +9,8 @@
   </ul>
   <div class = "search">
     <%= search_form_for @q, url: search_contents_path do |f| %>
-      <%= f.label :title_or_description_gt, 'キーワードを入力してください' %>
-      <%= f.search_field :title_or_description_gt %>
+      <%= f.label :title_or_description_cont_any, 'キーワードを入力してください' %>
+      <%= f.search_field :title_or_description_cont_any %>
       <br>
       <%= f.submit '検索' %>
     <% end %>

--- a/app/views/contents/new.html.erb
+++ b/app/views/contents/new.html.erb
@@ -28,6 +28,11 @@
       <%= form.file_field :video %>
     </div>
 
+    <div class = "field">
+      <%= form.label :youtube_url%>
+      <%= form.text_field :youtube_url %>
+    </div>    
+
     <div class="field">
       <%= form.label :text %>
       <%= form.rich_text_area :text %>

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -10,6 +10,16 @@
       <h2 class="content-title"><%= @content.title %></h2>
       <p class="content-description"><%= @content.description %></p>
       <hr>
+      <% if @content.video.present? %>
+      <div class = "content-video">
+        <%= video_tag(@content.video.to_s, :size => "400x300", :controls => true)  %>
+      </div>
+      <% end %>
+      <% if @content.youtube_url.present? %>
+      <div class="content-youtube">
+        <iframe src="https://www.youtube.com/embed/<%= @content.youtube_url.last(11) %>" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="" frameborder="0" height="315" width="560"></iframe>
+      </div>
+      <% end %>
       <div class="content-content">
         <%= @content.text %>
       </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,7 +14,7 @@ ja:
       # 各モデルのカラム名を記載
       category:
         title: タイトル
-        description: 同じ説明
+        description: 説明
       content:
         title: タイトル
         about: 概要

--- a/db/migrate/20230501083853_add_column_to_contents.rb
+++ b/db/migrate/20230501083853_add_column_to_contents.rb
@@ -1,0 +1,5 @@
+class AddColumnToContents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :contents, :image, :string
+  end
+end

--- a/db/migrate/20230502020915_add_youtube_url_to_contents.rb
+++ b/db/migrate/20230502020915_add_youtube_url_to_contents.rb
@@ -1,0 +1,5 @@
+class AddYoutubeUrlToContents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :contents, :youtube_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_01_083853) do
+ActiveRecord::Schema.define(version: 2023_05_02_020915) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 2023_05_01_083853) do
     t.string "video"
     t.string "admin_id", default: "", null: false
     t.string "image"
+    t.string "youtube_url"
     t.index ["user_id"], name: "index_contents_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_01_081448) do
+ActiveRecord::Schema.define(version: 2023_05_01_083853) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2023_05_01_081448) do
     t.integer "user_id", null: false
     t.string "video"
     t.string "admin_id", default: "", null: false
+    t.string "image"
     t.index ["user_id"], name: "index_contents_on_user_id"
   end
 


### PR DESCRIPTION
**contentsモデルのshowページに動画を表示する仕様**

1. contentsモデルにyoutube_urlカラムを追加し、youtubeの埋め込みに対応
2. showページにアップロードしたvideoファイルが表示されるようにhtmlを編集
3. 動画のリサイズ機能は一応搭載。レイアウトは未実施
4. uploadされた動画はignoreにてgitには上げない。
5. 画像アップロード時、ファイル名、大きさが表示されないようにhtml編集
