### PR TITLE
fix カラムのja.yml化、actiontextの画像の制限

### DIFF
--- a/app/uploaders/action_text_image_uploader.rb
+++ b/app/uploaders/action_text_image_uploader.rb
@@ -35,9 +35,9 @@ class ActionTextImageUploader < CarrierWave::Uploader::Base
 
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_allowlist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_allowlist
+    %w(jpg jpeg gif png)
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -23,10 +23,12 @@ ja:
         description: 説明
         video: 動画
         text: 本文
+        youtube_url: YoutubeのURL
       user:
         name: 名前
         email: メールアドレス
         password: パスワード
+        admin_id: マネジメントID
       post:
         content: 説明
         image: 画像


### PR DESCRIPTION
1. admin_idをマネジメントIDに日本語化
2. actiontext内のファイルを画像ファイルのみに制限