### PR TITLE
fix adminモデルのログイン機能、カラム編集、リレーションを実装

### DIFF
--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -1,6 +1,6 @@
 .box {
   margin: 2rem auto;
-  width: 400px;
+  width: 500px;
   border: 1px solid #eee;
   border-radius: 5px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,6 +1,10 @@
 class Admin < ApplicationRecord
+
+  has_many :contents
+  has_many :categories
+  has_many :users
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+        :recoverable, :rememberable, :validatable
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,4 +5,5 @@ class Category < ApplicationRecord
 
   has_many :contents
   belongs_to :user
+  belongs_to :admin
 end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -6,6 +6,7 @@ class Content < ApplicationRecord
   validate :text_required
 
   belongs_to :user
+  belongs_to :admin
   has_rich_text :text
   belongs_to :category
   mount_uploader :video, VideoUploader

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
 
   has_many :contents
   has_many :categories
+  belongs_to :user
 
   devise :database_authenticatable, :registerable,
         :recoverable, :rememberable, :validatable

--- a/app/views/admins/passwords/edit.html.erb
+++ b/app/views/admins/passwords/edit.html.erb
@@ -1,25 +1,37 @@
-<h2>Change your password</h2>
+<%= form_with model: @user, url: user_password_path, method: :patch, class: 'registration-main', local: true do |f| %>
+<div class='form-wrap'>
+  <div class='form-header'>
+    <h1 class='form-header-text'>
+      パスワード再設定
+    </h1>
+  </div>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "admins/shared/error_messages", resource: resource %>
+  <div class="form-group">
+    <div class='form-text-wrap'>
+      <label class="form-text">新しいパスワード</label>
+      <span class="indispensable">必須</span>
+    </div>
+    <%= f.password_field :password, class:"input-default", id:"password", placeholder:"6文字以上の半角英数字" %>
+    <p class='info-text'>※英字と数字の両方を含めて設定してください</p>
+  </div>
+  <div class="form-group">
+    <div class='form-text-wrap'>
+      <label class="form-text">パスワード(確認)</label>
+      <span class="indispensable">必須</span>
+    </div>
+    <%= f.password_field :password_confirmation, class:"input-default", id:"password-confirmation" %>
+  </div>
+
+  <%# 隠しフィールドでトークンもパラメーターで送る。こうすることでDBに保存されているリセットトークンとここから送られたトークンが一致するか確認している。 %>
   <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+  <div class="form-group">
+    <h2 class='form-bottom-text'>
+      よろしければ以下のボタンを押してください
+    </h2>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  <div class='register-btn'>
+    <%= f.submit "パスワードを変更する" ,class:"register-red-btn" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
+</div>
 <% end %>
-
-<%= render "admins/shared/links" %>

--- a/app/views/admins/passwords/new.html.erb
+++ b/app/views/admins/passwords/new.html.erb
@@ -1,16 +1,16 @@
-<h2>Forgot your password?</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "admins/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="box">
+  <div class="box-inner">
+    <h2>パスワード再設定</h2><p>
+    <h2>(マネージャーアカウント専用)</h2>
+    <%= form_with scope: :user, url: user_password_path, local: true do |f| %>
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, class: "form-control" %>
+      </div>
+      <div class="actions">
+        <%= f.submit "再設定メールを送信", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+    <%= render "users/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "admins/shared/links" %>
+</div>

--- a/app/views/admins/registrations/edit.html.erb
+++ b/app/views/admins/registrations/edit.html.erb
@@ -1,43 +1,27 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="box">
+  <div class="box-inner">
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "users/shared/error_messages", resource: resource %>
+      <h2>アカウント情報の編集</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "admins/shared/error_messages", resource: resource %>
+      <div class="box-email">
+        <%= f.label :email, "メールアドレス" %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+        <div class="box-email">
+          <p>アカウント確認用のメールが送信されています。変更内容が有効になるには、メール内のリンクをクリックして確認してください。</p>
+        </div>
+      <% end %>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <div class="actions">
+        <%= f.submit "変更を保存する" %>
+      </div>
     <% end %>
+
+    <div class="login">
+      <%= link_to "アカウントを削除する", registration_path(resource_name), method: :delete, data: { confirm: "本当にアカウントを削除しますか？" } %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/admins/registrations/new.html.erb
+++ b/app/views/admins/registrations/new.html.erb
@@ -23,11 +23,6 @@
         <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
       </div>
 
-      <div class="box-admin">
-        <%= f.label :admin, "マネージャー設定" %><br />
-        <%= f.check_box :admin %>
-      </div>
-
       <div class="box-admin-id">
         <%= f.label :project_id, "マネジメントID" %><br />
         <%= f.text_field :project_id, autocomplete: "project_id" %>

--- a/app/views/admins/sessions/new.html.erb
+++ b/app/views/admins/sessions/new.html.erb
@@ -1,26 +1,33 @@
-<h2>Log in</h2>
+<div class = "box">
+  <div class = "box-inner">
+    <h2>ログイン</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div class="box-email">
+        <%= f.label :email, "メールアドレス" %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      </div>
+
+      <div class="box-password">
+        <%= f.label :password, "パスワード" %><br />
+        <%= f.password_field :password, autocomplete: "current-password" %>
+      </div>
+
+      <% if devise_mapping.rememberable? %>
+        <div class="field">
+          <%= f.check_box :remember_me %>
+          <%= f.label :remember_me, "ログインを保持する"%>
+        </div>
+      <% end %>
+
+      <div class="actions">
+        <%= f.submit "ログイン" %>
+        <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name) %>
+      </div>
+    <% end %>
+
+    <%= render "users/shared/links" %>
+
   </div>
+</div>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "admins/shared/links" %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,6 +1,30 @@
 ja:
   activerecord:
     attributes:
+      admin:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
       user:
         confirmation_sent_at: パスワード確認送信時刻
         confirmation_token: パスワード確認用トークン
@@ -27,6 +51,7 @@ ja:
         updated_at: 更新日
     models:
       user: ユーザー
+      admin: マネージャー
   devise:
     confirmations:
       confirmed: メールアドレスが確認できました。

--- a/db/migrate/20230503085036_add_project_id_to_contents.rb
+++ b/db/migrate/20230503085036_add_project_id_to_contents.rb
@@ -1,0 +1,5 @@
+class AddProjectIdToContents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :contents, :project_id, :string
+  end
+end

--- a/db/migrate/20230503085224_add_project_id_to_categpries.rb
+++ b/db/migrate/20230503085224_add_project_id_to_categpries.rb
@@ -1,0 +1,5 @@
+class AddProjectIdToCategpries < ActiveRecord::Migration[6.1]
+  def change
+    add_column :categories, :project_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_03_030640) do
+ActiveRecord::Schema.define(version: 2023_05_03_085224) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 2023_05_03_030640) do
     t.string "description"
     t.integer "user_id"
     t.string "admin_id", default: "", null: false
+    t.string "project_id"
   end
 
   create_table "contacts", force: :cascade do |t|
@@ -92,6 +93,7 @@ ActiveRecord::Schema.define(version: 2023_05_03_030640) do
     t.string "admin_id", default: "", null: false
     t.string "image"
     t.string "youtube_url"
+    t.string "project_id"
     t.index ["user_id"], name: "index_contents_on_user_id"
   end
 


### PR DESCRIPTION
adminモデルにて以下を実装

1. adminのログイン機能のページを作成
・ログインページ
・サインアップページ
・アカウント編集ページ
・パスワード再発行ページ
・パスワード再発行設定ページ
・devise.ja.ymlの編集 