### PR TITLE
adminモデル追加にあたり、project_idを追加

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,0 +1,7 @@
+class AdminsController < ApplicationController
+  
+  before_action :authenticate_admin!
+  def show
+    @admin = Admin.find(params[:id])
+  end
+end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,8 +1,8 @@
 class CategoriesController < ApplicationController
-  before_action :authenticate_admin!
+  before_action :authenticate_admin_or_user!
   before_action :set_category, only: [:edit, :update, :destroy]
   before_action :set_project_id
-  #before_action :admin_required, except: [:index, :show]
+  before_action :admin_required, except: [:index, :show]
 
   def index
     @category = Category.new
@@ -44,6 +44,17 @@ class CategoriesController < ApplicationController
 
   private
 
+  def authenticate_admin_or_user!
+    if current_admin
+      authenticate_admin!
+    elsif current_user
+      authenticate_user!
+    else
+      flash[:alert] = "ログインが必要です"
+      redirect_to root_path
+    end
+  end
+
   def set_category
     @category = Category.find(params[:id])
   end
@@ -57,7 +68,7 @@ class CategoriesController < ApplicationController
   end
 
   def admin_required
-    unless current_user.admin?
+    unless admin_signed_in?
       flash[:alert] = "管理者権限が必要です"
       redirect_to root_path
     end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,23 +1,24 @@
 class CategoriesController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_admin!
   before_action :set_category, only: [:edit, :update, :destroy]
-  before_action :admin_required, except: [:index, :show]
+  before_action :set_project_id
+  #before_action :admin_required, except: [:index, :show]
 
   def index
     @category = Category.new
-    @categories = Category.where(admin_id: current_user.admin_id)
+    @categories = Category.where(project_id: @project_id)
   end
 
   def create
     @category = Category.new(category_params)
-    @category.admin_id = current_user.admin_id
-    @category.user_id = current_user.id
+    @category.project_id = @project_id
+    @category.admin_id = current_admin.id
     if @category.save
       flash[:notice] = "新規作成に成功しました"
       redirect_to categories_path
     else
       flash[:alert] = "エラーを確認してください"
-      @categories = Category.where(admin_id: current_user.admin_id)
+      @categories = Category.where(project_id: @project_id)
       render 'index'
     end
   end
@@ -49,6 +50,10 @@ class CategoriesController < ApplicationController
 
   def category_params
     params.require(:category).permit(:title, :description)
+  end
+
+  def set_project_id
+    @project_id = current_user&.project_id || current_admin&.project_id
   end
 
   def admin_required

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -1,9 +1,9 @@
 class ContentsController < ApplicationController
-  before_action :authenticate_admin!
+  before_action :authenticate_admin_or_user!
   before_action :set_project_id
   before_action :set_content,  only: [:edit, :update, :destroy, :show]
   before_action :set_q, only: [:index, :search]
-  #before_action :admin_required, except: [:index, :show]
+  before_action :admin_required, except: [:index, :show]
   
 
   def index
@@ -56,6 +56,17 @@ class ContentsController < ApplicationController
 
   private
 
+  def authenticate_admin_or_user!
+    if current_admin
+      authenticate_admin!
+    elsif current_user
+      authenticate_user!
+    else
+      flash[:alert] = "ログインが必要です"
+      redirect_to root_path
+    end
+  end
+
   def set_project_id
     @project_id = current_user&.project_id || current_admin&.project_id
   end
@@ -73,7 +84,7 @@ class ContentsController < ApplicationController
   end
 
   def admin_required
-    unless current_user.admin? || current_admin.admin?
+    unless admin_signed_in?
       flash[:alert] = "管理者権限が必要です"
       redirect_to root_path
     end

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -1,14 +1,14 @@
 class ContentsController < ApplicationController
-  before_action :authenticate_user!
-  before_action :set_admin_id
+  before_action :authenticate_admin!
+  before_action :set_project_id
   before_action :set_content,  only: [:edit, :update, :destroy, :show]
   before_action :set_q, only: [:index, :search]
-  before_action :admin_required, except: [:index, :show]
+  #before_action :admin_required, except: [:index, :show]
   
 
   def index
-    @contents = Content.where(admin_id: current_user.admin_id)
-    @categories = Category.where(admin_id: current_user.admin_id)
+    @contents = Content.where(project_id: @project_id)
+    @categories = Category.where(project_id: @project_id)
   end
 
   def new
@@ -20,8 +20,7 @@ class ContentsController < ApplicationController
 
   def create
     @content = Content.new(content_params)
-    @content.user_id = current_user.id
-    @content.admin_id = @admin_id
+    @content.project_id = @project_id
     if @content.save
       flash[:notice] = "新規作成に成功しました"
       redirect_to contents_path
@@ -52,17 +51,17 @@ class ContentsController < ApplicationController
   end
 
   def search
-    @results = @q.result.where(admin_id: current_user.admin_id)
+    @results = @q.result.where(project_id: @project_id)
   end
 
   private
 
-  def set_admin_id
-    @admin_id = current_user.admin_id
+  def set_project_id
+    @project_id = current_user&.project_id || current_admin&.project_id
   end
 
   def content_params
-    params.require(:content).permit(:title, :about, :category_id, :image, :description, :text, :video, :youtube_url)
+    params.require(:content).permit(:title, :about, :category_id, :image, :description, :text, :video, :youtube_url, :project_id, :admin_id)
   end
 
   def set_content
@@ -74,7 +73,7 @@ class ContentsController < ApplicationController
   end
 
   def admin_required
-    unless current_user.admin?
+    unless current_user.admin? || current_admin.admin?
       flash[:alert] = "管理者権限が必要です"
       redirect_to root_path
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!
   
   def show
     @user = User.find(params[:id])

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,8 +1,9 @@
 class Admin < ApplicationRecord
 
-  has_many :contents
-  has_many :categories
+  has_many :contents, dependent: :destroy
+  has_many :categories, dependent: :destroy
   has_many :users
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,5 +1,7 @@
 class Admin < ApplicationRecord
 
+  validates :admin_id, presence: true, length: {in:6..10 }, uniqueness: true
+
   has_many :contents, dependent: :destroy
   has_many :categories, dependent: :destroy
   has_many :users

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,6 +4,5 @@ class Category < ApplicationRecord
   validates :description, presence: true, length: {maximum: 30},uniqueness: true
 
   has_many :contents
-  belongs_to :user
   belongs_to :admin
 end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -5,7 +5,6 @@ class Content < ApplicationRecord
   validates :description, presence: true, length: {maximum: 30}
   validate :text_required
 
-  belongs_to :user
   belongs_to :admin
   has_rich_text :text
   belongs_to :category

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,10 +2,7 @@ class User < ApplicationRecord
 
   validates :admin_id, presence: true, length: {in:6..10 }
 
-  has_many :contents
-  has_many :categories
-  belongs_to :user
-
+  belongs_to :admin
   devise :database_authenticatable, :registerable,
         :recoverable, :rememberable, :validatable
 end

--- a/app/views/admins/mailer/reset_password_instructions.html.erb
+++ b/app/views/admins/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,15 @@
-<p>Hello <%= @resource.email %>!</p>
+<%# メールの文仮　%>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
-
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
-
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= @resource.email %> 様</p>
+<br>
+<hr>
+<br>
+<p>パスワードの変更がリクエストされました。以下のリンクから変更を行ってください。</p>
+<br>
+<p><%= link_to 'パスワードを変更する', edit_user_password_url(@resource, reset_password_token: @token) %></p>
+<br>
+<hr>
+<br>
+<p>もし、このリクエストをしていない場合は、このメールを無視してください。</p>
+<br>
+<p>リンク先にアクセスし、新しいパスワードを作成するまで、現在のパスワードは有効です。</p>

--- a/app/views/admins/passwords/edit.html.erb
+++ b/app/views/admins/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @user, url: user_password_path, method: :patch, class: 'registration-main', local: true do |f| %>
+<%= form_with model: @admin, url: admin_password_path, method: :patch, class: 'registration-main', local: true do |f| %>
 <div class='form-wrap'>
   <div class='form-header'>
     <h1 class='form-header-text'>

--- a/app/views/admins/passwords/new.html.erb
+++ b/app/views/admins/passwords/new.html.erb
@@ -2,7 +2,7 @@
   <div class="box-inner">
     <h2>パスワード再設定</h2><p>
     <h2>(マネージャーアカウント専用)</h2>
-    <%= form_with scope: :user, url: user_password_path, local: true do |f| %>
+    <%= form_with scope: :admin, url: admin_password_path, local: true do |f| %>
       <div class="field">
         <%= f.label :email %><br />
         <%= f.email_field :email, autofocus: true, class: "form-control" %>

--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -1,0 +1,5 @@
+<div class="user-info">
+  <p>email: <%= @admin.email %></p>
+  <p>Project ID: <%= @admin.project_id %></p>
+  <%= link_to "アカウントを編集する", edit_admin_registration_path, class: "btn btn-primary" %>
+</div>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,6 +1,7 @@
 <div class="row">
   <div class="col-xs-3">
     <%= form_with model: @category, url: categories_path do |f| %>
+    <%= render 'shared/eerror', object: f.object %>
       <%= f.label :title, 'カテゴリー名' %>
       <br>
       <%= f.text_field :title, class: 'form-control', id: 'category-title' %>

--- a/app/views/contents/index.html.erb
+++ b/app/views/contents/index.html.erb
@@ -38,12 +38,12 @@
                     <div class = "content-description">
                       <%= content.description %>
                     </div>
-                    <% if current_user.admin? %>
+                      <% if admin_signed_in? %>
                       <div class="content-update">
                         <%= link_to "編集", edit_content_path(content) %>
                         <%= link_to "削除", content, method: :delete, data: { confirm: "本当に削除しますか?" } %>
                       </div>
-                    <% end %>
+                      <% end %>
                   </div>
                 </div>
               </div>

--- a/app/views/contents/new.html.erb
+++ b/app/views/contents/new.html.erb
@@ -1,6 +1,7 @@
 <div class = "content-create">
   <h1>New Content</h1>
   <%= form_with(model: @content, local: true) do |form| %>
+  <%= render 'shared/eerror', object: form.object %>
     <div class="field">
       <%= form.label :title %>
       <%= form.text_field :title %>
@@ -38,7 +39,7 @@
       <%= form.rich_text_area :text %>
       <%= render 'shared/error_messages', object: @content, attribute: :text %>
     </div>
-
+    <%= form.hidden_field :admin_id, value: current_admin.id %>
     <div class="actions">
       <%= form.submit %>
     </div>

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -4,7 +4,7 @@
     </div>
     <div class="content-detail">
       <div class="content-update">
-      <% if current_user.admin? %>
+      <% if admin_signed_in? %>
         <%= link_to "編集", edit_content_path(@content) %>
         <%= link_to "削除", @content, method: :delete, data: { confirm: "本当に削除しますか?" } %>
       <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,7 +4,7 @@
   </div>
   <h1 class = "welcome" >研修アプリへようこそ</h1>
   <ul class = "content-lists">
-    <% if user_signed_in? && current_user.admin %>
+    <% if admin_signed_in? %>
     <li class = "content"><%= link_to "研修一覧",contents_path%></li>
     <li class = "content"><%= link_to "研修作成", new_content_path%></li>
     <% elsif user_signed_in?  %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,8 @@
             <li><%= link_to "Login", new_user_session_path %></li>
             <li><%= link_to "Sign up", new_user_registration_path %></li>
             <li><%= link_to "admin", new_admin_registration_path %></li>
+            <li><%= link_to "Logout", destroy_admin_session_path, method: :delete %></li>
+            <li><%= link_to "Login", new_admin_session_path %></li>
           </ul>
         <% end %>
       </nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,15 +22,19 @@
             <li><%= link_to "Profile", user_path(current_user) %></li>
             <li><%= link_to "Logout", destroy_user_session_path, method: :delete %></li>
           </ul>
+        <% elsif admin_signed_in? %>
+          <ul>
+            <li><%= current_admin.email%>(管理者)</li>
+            <li><%= link_to "Home", root_path %></li>
+            <li><%= link_to "Profile", admin_path(current_admin) %></li>
+            <li><%= link_to "Logout", destroy_admin_session_path, method: :delete %></li>
+          </ul>
         <% else %>
           <ul>
             <li><%= link_to "Home", root_path %></li>
             <li><%= link_to "About", about_path %></li>
-            <li><%= link_to "Login", new_user_session_path %></li>
-            <li><%= link_to "Sign up", new_user_registration_path %></li>
-            <li><%= link_to "admin", new_admin_registration_path %></li>
-            <li><%= link_to "Logout", destroy_admin_session_path, method: :delete %></li>
-            <li><%= link_to "Login", new_admin_session_path %></li>
+            <li><%= link_to "ログインはこちら", new_user_session_path %></li>
+            <li><%= link_to "管理者はこちら", new_admin_session_path %></li>
           </ul>
         <% end %>
       </nav>

--- a/app/views/shared/_eerror.html.erb
+++ b/app/views/shared/_eerror.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div class="alert alert-danger">
+    <ul class="mb-0">
+      <% object.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -22,14 +22,9 @@
         <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
       </div>
 
-      <div class="box-admin">
-        <%= f.label :admin, "マネージャー設定" %><br />
-        <%= f.check_box :admin %>
-      </div>
-
       <div class="box-admin-id">
-        <%= f.label :admin_id, "マネジメントID" %><br />
-        <%= f.text_field :admin_id, autocomplete: "admin_id" %>
+        <%= f.label :project_id, "マネジメントID" %><br />
+        <%= f.text_field :project_id, autocomplete: "project_id" %>
       </div>
 
       <div class="actions">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
 <div class="user-info">
   <p>email: <%= @user.email %></p>
-  <p>Admin ID: <%= @user.admin_id %></p>
+  <p>Project ID: <%= @user.project_id %></p>
   <%= link_to "アカウントを編集する", edit_user_registration_path, class: "btn btn-primary" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
   end
   resources :categories, expect: [:new, :show]
   resources :users, only: [:show]
+  resources :admins, only: [:show]
   resources :contacts, only: [:new, :create]
   post 'contacts/confirm', to: 'contacts#confirm', as: 'confirm'
 

--- a/db/migrate/20230503123344_remove_user_id_from_contents.rb
+++ b/db/migrate/20230503123344_remove_user_id_from_contents.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromContents < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :contents, :user_id, :integer
+  end
+end

--- a/db/migrate/20230503131250_remove_user_id_from_categories.rb
+++ b/db/migrate/20230503131250_remove_user_id_from_categories.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromCategories < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :categories, :user_id, :integer
+  end
+end

--- a/db/migrate/20230503134027_remove_project_id_from_contents.rb
+++ b/db/migrate/20230503134027_remove_project_id_from_contents.rb
@@ -1,0 +1,5 @@
+class RemoveProjectIdFromContents < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :contents, :project_id, :string
+  end
+end

--- a/db/migrate/20230503134100_remove_project_id_from_categories.rb
+++ b/db/migrate/20230503134100_remove_project_id_from_categories.rb
@@ -1,0 +1,5 @@
+class RemoveProjectIdFromCategories < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :categories, :project_id, :string
+  end
+end

--- a/db/migrate/20230503134241_rename_admin_id_column_to_contents.rb
+++ b/db/migrate/20230503134241_rename_admin_id_column_to_contents.rb
@@ -1,0 +1,5 @@
+class RenameAdminIdColumnToContents < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :contents, :admin_id, :project_id
+  end
+end

--- a/db/migrate/20230503134319_rename_admin_id_column_to_categories.rb
+++ b/db/migrate/20230503134319_rename_admin_id_column_to_categories.rb
@@ -1,0 +1,5 @@
+class RenameAdminIdColumnToCategories < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :categories, :admin_id, :project_id
+  end
+end

--- a/db/migrate/20230503134906_rename_admin_id_column_to_users.rb
+++ b/db/migrate/20230503134906_rename_admin_id_column_to_users.rb
@@ -1,0 +1,5 @@
+class RenameAdminIdColumnToUsers < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :users, :admin_id, :project_id
+  end
+end

--- a/db/migrate/20230503135200_remove_admin_from_users.rb
+++ b/db/migrate/20230503135200_remove_admin_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveAdminFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :admin, :boolean
+  end
+end

--- a/db/migrate/20230503141131_add_admin_id_to_contents.rb
+++ b/db/migrate/20230503141131_add_admin_id_to_contents.rb
@@ -1,5 +1,5 @@
 class AddAdminIdToContents < ActiveRecord::Migration[6.1]
   def change
-    add_column :contents, :admin_id, :string, null: false, default: ""
+    add_column :contents, :admin_id, :integer
   end
 end

--- a/db/migrate/20230503141159_add_admin_id_to_categories.rb
+++ b/db/migrate/20230503141159_add_admin_id_to_categories.rb
@@ -1,5 +1,5 @@
 class AddAdminIdToCategories < ActiveRecord::Migration[6.1]
   def change
-    add_column :categories, :admin_id, :string, null: false, default: ""
+    add_column :categories, :admin_id, :integer
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_03_085224) do
+ActiveRecord::Schema.define(version: 2023_05_03_141159) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -69,9 +69,8 @@ ActiveRecord::Schema.define(version: 2023_05_03_085224) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "description"
-    t.integer "user_id"
-    t.string "admin_id", default: "", null: false
-    t.string "project_id"
+    t.string "project_id", default: "", null: false
+    t.integer "admin_id"
   end
 
   create_table "contacts", force: :cascade do |t|
@@ -88,13 +87,11 @@ ActiveRecord::Schema.define(version: 2023_05_03_085224) do
     t.string "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "user_id", null: false
     t.string "video"
-    t.string "admin_id", default: "", null: false
+    t.string "project_id", default: "", null: false
     t.string "image"
     t.string "youtube_url"
-    t.string "project_id"
-    t.index ["user_id"], name: "index_contents_on_user_id"
+    t.integer "admin_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -105,13 +102,11 @@ ActiveRecord::Schema.define(version: 2023_05_03_085224) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "admin_id", default: ""
-    t.boolean "admin", default: false
+    t.string "project_id", default: ""
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "contents", "users"
 end


### PR DESCRIPTION
adminモデル導入にあたり、userモデルから以下を変更

1. userモデルからadmin機能をadminモデルに移植
2. admin_idをproject_idに変名（admin_idはadminモデルと衝突するため）
3. userモデルのadminカラムで機能していたものをadminモデルに移植
4. それに応じてview、before_actionを変更