### PR TITLE
fix rspec systemテスト追加、fix admin編集ページの編集

### DIFF
--- a/app/views/admins/registrations/edit.html.erb
+++ b/app/views/admins/registrations/edit.html.erb
@@ -9,11 +9,10 @@
         <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
       </div>
 
-      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-        <div class="box-email">
-          <p>アカウント確認用のメールが送信されています。変更内容が有効になるには、メール内のリンクをクリックして確認してください。</p>
-        </div>
-      <% end %>
+      <div class="box-password">
+        <%= f.label :current_password,"現在のパスワード"%> <i>(変更を完了するには登録しているパスワードを入力してください)</i><br />
+        <%= f.password_field :current_password, autocomplete: "current-password" %>
+      </div>
 
       <div class="actions">
         <%= f.submit "変更を保存する" %>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require 'support/factory_bot'
 require'devise'
 require File.expand_path("spec/support/controller_macros.rb")
 require_relative 'support/controller_macros'
+require 'capybara/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -66,4 +67,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include Capybara::DSL
+  config.include Warden::Test::Helpers
 end

--- a/spec/system/admins/admins_registrations_controllers_spec.rb
+++ b/spec/system/admins/admins_registrations_controllers_spec.rb
@@ -4,28 +4,53 @@ RSpec.describe "Admins::RegistrationsControllers", type: :system do
   before do
     @admin = create(:admin)
   end
+  context '新規登録について' do
+    scenario 'admin(管理者)が新規登録できること' do
+      visit new_admin_registration_path
+      fill_in 'admin[email]', with: 'new@example.com'
+      fill_in 'admin[password]', with: 'password'
+      fill_in 'admin[password_confirmation]', with: 'password'
+      fill_in 'admin[project_id]', with: 'admin1'
+      click_button 'アカウントを作成する'
+    
+      expect(current_path).to eq root_path
+      expect(page).to have_content 'アカウント登録が完了しました'
+    end
 
-  scenario 'admin(管理者)が新規登録できること' do
-    visit new_admin_registration_path
-    fill_in 'admin[email]', with: 'new@example.com'
-    fill_in 'admin[password]', with: 'password'
-    fill_in 'admin[password_confirmation]', with: 'password'
-    fill_in 'admin[project_id]', with: 'admin1'
-    click_button 'アカウントを作成する'
-  
-    expect(current_path).to eq root_path
-    expect(page).to have_content 'アカウント登録が完了しました'
+    scenario '不備があると新規登録ができないこと' do
+      visit new_admin_registration_path
+      fill_in 'admin[email]', with: 'new@example.com'
+      fill_in 'admin[password]', with: 'password'
+      fill_in 'admin[password_confirmation]', with: ''
+      fill_in 'admin[project_id]', with: 'admin1'
+      click_button 'アカウントを作成する'
+    
+      expect(current_path).to eq admin_registration_path
+      expect(page).to have_content '保存されませんでした'
+    end
   end
 
-  scenario 'admin(管理者)が情報を編集できること' do
-    login_as(@admin)
-    visit edit_admin_registration_path
-    fill_in 'admin[email]', with: 'new@example.com'
-    fill_in 'admin[current_password]', with: 'password' 
-    click_button '変更を保存する'
-  
-    expect(current_path).to eq root_path
-    expect(page).to have_content 'アカウント情報を変更しました'
+  context 'ログイン機能について' do
+    scenario 'admin(管理者)が情報を編集できること' do
+      login_as(@admin)
+      visit edit_admin_registration_path
+      fill_in 'admin[email]', with: 'new@example.com'
+      fill_in 'admin[current_password]', with: 'password' 
+      click_button '変更を保存する'
+    
+      expect(current_path).to eq root_path
+      expect(page).to have_content 'アカウント情報を変更しました'
+    end
+
+    scenario '現在のパスワードが不足すると編集できないこと' do
+      login_as(@admin)
+      visit edit_admin_registration_path
+      fill_in 'admin[email]', with: 'new@example.com'
+      fill_in 'admin[current_password]', with: '' 
+      click_button '変更を保存する'
+    
+      expect(current_path).to eq admin_registration_path
+      expect(page).to have_content '保存されませんでした'
+    end
   end
-  
 end

--- a/spec/system/admins/admins_registrations_controllers_spec.rb
+++ b/spec/system/admins/admins_registrations_controllers_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe "Admins::RegistrationsControllers", type: :system do
+  before do
+    @admin = create(:admin)
+  end
+
+  scenario 'admin(管理者)が新規登録できること' do
+    visit new_admin_registration_path
+    fill_in 'admin[email]', with: 'new@example.com'
+    fill_in 'admin[password]', with: 'password'
+    fill_in 'admin[password_confirmation]', with: 'password'
+    fill_in 'admin[project_id]', with: 'admin1'
+    click_button 'アカウントを作成する'
+  
+    expect(current_path).to eq root_path
+    expect(page).to have_content 'アカウント登録が完了しました'
+  end
+
+  scenario 'admin(管理者)が情報を編集できること' do
+    login_as(@admin)
+    visit edit_admin_registration_path
+    fill_in 'admin[email]', with: 'new@example.com'
+    fill_in 'admin[current_password]', with: 'password' 
+    click_button '変更を保存する'
+  
+    expect(current_path).to eq root_path
+    expect(page).to have_content 'アカウント情報を変更しました'
+  end
+  
+end

--- a/spec/system/admins_controllers_spec.rb
+++ b/spec/system/admins_controllers_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe "AdminsControllers", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/system/application_controllers_spec.rb
+++ b/spec/system/application_controllers_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe "ApplicationControllers", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/system/categories_controllers_spec.rb
+++ b/spec/system/categories_controllers_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe "CategoriesControllers", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/system/contacts_controllers_spec.rb
+++ b/spec/system/contacts_controllers_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe "ContactsControllers", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/system/contents_controllers_spec.rb
+++ b/spec/system/contents_controllers_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe "ContentsControllers", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/system/users/users_registrations_controllers_spec.rb
+++ b/spec/system/users/users_registrations_controllers_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe "Users::RegistrationsControllers", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/system/users_controllers_spec.rb
+++ b/spec/system/users_controllers_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe "UsersControllers", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  pending "add some scenarios (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
rspec systemspec導入
以下のファイルを作成

> ログイン関係
・admins_registrations_controllers_spec
・users_registrations_controllers_spec

> 詳細関係
・admins_controllers_spec
・users_controllers_spec

> 機能関係
・application_controllers_spec
・categories_controllers_spec
・contacts_controllers_spec
・contents_controllers_spec
・users_controllers_spec

- ・admins_registrations_controllers_specにて
scenario 'admin(管理者)が情報を編集できること' do部分について
テストが通らないため、viewの一部を変更。