### PR TITLE
add category機能のsystemSpec導入

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,5 +1,5 @@
 class CategoriesController < ApplicationController
-  before_action :authenticate_admin_or_user!
+  before_action :authenticate_admin!
   before_action :set_category, only: [:edit, :update, :destroy]
   before_action :set_project_id
   before_action :admin_required, except: [:index, :show]
@@ -43,17 +43,6 @@ class CategoriesController < ApplicationController
   end
 
   private
-
-  def authenticate_admin_or_user!
-    if current_admin
-      authenticate_admin!
-    elsif current_user
-      authenticate_user!
-    else
-      flash[:alert] = "ログインが必要です"
-      redirect_to root_path
-    end
-  end
 
   def set_category
     @category = Category.find(params[:id])

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,7 +1,6 @@
 <div class="row">
   <div class="col-xs-3">
     <%= form_with model: @category, url: categories_path do |f| %>
-    <%= render 'shared/eerror', object: f.object %>
       <%= f.label :title, 'カテゴリー名' %>
       <br>
       <%= f.text_field :title, class: 'form-control', id: 'category-title' %>

--- a/app/views/contents/new.html.erb
+++ b/app/views/contents/new.html.erb
@@ -15,7 +15,7 @@
     </div>
 
     <div class = "category-message">
-      <p>該当するカテゴリーがない場合、<%= link_to 'こちら', categories_path %>から登録してください。</p>
+      <p>該当するカテゴリーがない場合、<%= link_to 'ここ', categories_path %>から登録してください。</p>
     </div>
 
     <div class="field">

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,8 +1,15 @@
 FactoryBot.define do
   factory :category do
-    sequence(:title) { |n| 'title#{n}'}
-    sequence(:description) { |n| 'test#{n}'}
+    title { 'title' }
+    description { 'description'}
     admin
     project_id {admin.project_id}
+  end
+
+  factory :category2 do
+    title { 'title1' }
+    description { 'description1'}
+    project_id { '111111' }
+    admin_id {'1'}
   end
 end

--- a/spec/system/application_controllers_spec.rb
+++ b/spec/system/application_controllers_spec.rb
@@ -121,8 +121,8 @@ RSpec.describe "ApplicationControllers", type: :system do
 
     scenario 'categories/indexに遷移しないこと' do
       visit categories_path
-      expect(current_path).to eq root_path
-      expect(page).to have_content 'ログインが必要です'
+      expect(current_path).to eq new_admin_session_path
+      expect(page).to have_content 'ログインもしくはアカウント登録してください。'
     end
   end
 end

--- a/spec/system/categories_controllers_spec.rb
+++ b/spec/system/categories_controllers_spec.rb
@@ -1,9 +1,124 @@
 require 'rails_helper'
 
 RSpec.describe "CategoriesControllers", type: :system do
-  before do
-    driven_by(:rack_test)
+
+  let(:admin) {create(:admin)}
+  let(:user) {create(:user)}
+  let(:category) {build(:category)}
+  let(:content) {create(:content)}
+
+  context 'カテゴリーのアクセス制限について' do
+    before  do
+      visit root_path
+    end
+
+    scenario 'admin(管理者)であればアクセスできること' do
+      login_as(admin, :scope => :admin)
+      visit categories_path
+      expect(current_path).to eq categories_path
+      expect(page).to have_content 'カテゴリー名'
+    end
+
+    scenario 'admin(管理者)であれば、content作成画面から移行できること' do
+      visit new_admin_session_path
+      fill_in 'admin[email]', with: admin.email
+      fill_in 'admin[password]', with: admin.password
+      click_button 'ログイン'
+      click_link '研修作成'
+      click_link 'ここ'
+      expect(current_path).to eq categories_path
+      expect(page).to have_content 'カテゴリー名'
+    end
+
+    scenario 'user(利用者)はアクセスできないこと' do
+      login_as(user, :scope => :user)
+      visit categories_path
+      expect(current_path).to eq new_admin_session_path
+      expect(page).to have_content 'ログインもしくはアカウント登録してください。'
+    end
+
+    scenario '非ログイン時はアクセスできないこと' do
+      visit categories_path
+      expect(current_path).to eq new_admin_session_path
+      expect(page).to have_content 'ログインもしくはアカウント登録してください。'
+    end
   end
 
-  pending "add some scenarios (or delete) #{__FILE__}"
+  context 'カテゴリーの新規作成について' do
+    before do
+      visit new_admin_session_path
+      fill_in 'admin[email]', with: admin.email
+      fill_in 'admin[password]', with: admin.password
+      click_button 'ログイン'
+    end
+
+    scenario 'カテゴリーの新規作成ができること' do
+      visit categories_path
+      fill_in 'category[title]', with: 'testだよ'
+      fill_in 'category[description]', with: 'testなんですよ'
+      click_button '追加'
+      expect(current_path).to eq categories_path
+      expect(page).to have_content 'testだよ'
+      expect(page).to have_content 'testなんですよ'
+    end
+
+    scenario 'カテゴリーの新規作成ができること' do
+      visit categories_path
+      fill_in 'category[title]', with: 'testだよ'
+      fill_in 'category[description]', with: 'testなんですよ'
+      click_button '追加'
+      expect(current_path).to eq categories_path
+      expect(page).to have_content 'testだよ'
+      expect(page).to have_content 'testなんですよ'
+    end
+
+    scenario '「カテゴリー名」「カテゴリー説明」の両方の入力がない時、追加ボタンを押せないこと' do
+      visit categories_path
+      fill_in 'category[title]', with: "カテゴリ失敗"
+      fill_in 'category[description]', with: ""
+      expect(page).to have_button("追加", disabled: true)
+      fill_in 'category[description]', with: "テストテスト"
+      expect(page).to have_button("追加", disabled: false)
+    end
+
+    scenario '同じカテゴリー名、説明は登録できないこと' do
+      visit categories_path
+      fill_in 'category[title]', with: 'title'
+      fill_in 'category[description]', with: 'description'
+      click_button '追加'
+      fill_in 'category[title]', with: 'title'
+      fill_in 'category[description]', with: 'description'
+      click_button '追加'
+      expect(page).to have_content 'エラーを確認してください'
+      expect(page).to have_content 'タイトルはすでに存在します'
+      expect(page).to have_content '説明はすでに存在します'
+    end
+  end
+
+  context 'カテゴリーの編集、削除について' do
+    before do
+      login_as(admin, :scope => :admin)
+      visit categories_path
+      fill_in 'category[title]', with: '短くしたいな'
+      fill_in 'category[description]', with: '短くしたいな'
+      click_button '追加'
+    end
+
+    scenario 'カテゴリーが編集できること' do
+      click_link '編集'
+      fill_in 'category[title]', with: 'testだよ'
+      fill_in 'category[description]', with: 'testなんですよ'
+      click_button '更新する'
+      expect(current_path).to eq categories_path
+      expect(page).to have_content 'testだよ'
+      expect(page).to have_content 'testなんですよ'
+    end
+
+    scenario 'カテゴリーが削除できること' do
+      click_link '削除'
+      page.accept_confirm
+      expect(page).to have_content 'カテゴリーを削除しました'
+      expect(page).not_to have_content 'testだよ'
+    end
+  end
 end


### PR DESCRIPTION
systemSpecにてカテゴリー機能のテストを導入

> アクセス制限

> 新規作成

> 編集、削除

について記述した。
FactoryBotのcategoryがうまく生成できていないようなのでベタ書きで対応。