### PR TITLE
fix ログイン後、サインアップ後にcontents/indexに移行

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,4 +8,12 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:admin, :adminId])
     devise_parameter_sanitizer.permit(:account_update, keys: [:admin, :adminId])
   end
+
+  def after_sign_in_path_for(resource)
+    contents_path
+  end
+
+  def after_sign_up_path_for(resource)
+    contents_path
+  end
 end


### PR DESCRIPTION
ログイン、サインアップ時にcontents一覧に行くように調節。

1. after_sign_in_path_for(resource)の追加
2. after_sign_up_path_for(resource)の追加